### PR TITLE
fix: transform Tool Use output to langextract format for schema extra…

### DIFF
--- a/langextract_bedrock/provider.py
+++ b/langextract_bedrock/provider.py
@@ -326,9 +326,15 @@ class BedrockLanguageModel(lx.core.base_model.BaseLanguageModel):
             # langextract expects: {"extractions": [{"X": "Y", "X_attributes": {...}}]}
             tool_input = tool_use_part.get("input") or {}
             extractions = tool_input.get("extractions", [])
+            if not isinstance(extractions, list):
+                raise ValueError(f"Tool Use response has invalid 'extractions' type: {type(extractions).__name__}")
             transformed = []
             for ext in extractions:
-                cls_name = ext.get("extraction_class", "")
+                if not isinstance(ext, dict):
+                    raise ValueError(f"Tool Use extraction item is not a dict: {type(ext).__name__}")
+                cls_name = ext.get("extraction_class")
+                if not cls_name:
+                    continue  # Skip extractions without a class name
                 item = {cls_name: ext.get("extraction_text", "")}
                 attrs = ext.get("attributes")
                 if attrs is not None:

--- a/langextract_bedrock/provider.py
+++ b/langextract_bedrock/provider.py
@@ -321,10 +321,20 @@ class BedrockLanguageModel(lx.core.base_model.BaseLanguageModel):
             response = self.client.converse(**followup_kwargs)
             content = response.get("output", {}).get("message", {}).get("content", [])
         elif tool_use_part and not tool_executor:
-            # Schema-based extraction: tool was used but no executor needed
-            # The structured data is in toolUse.input, return it directly
+            # Schema-based extraction: transform Tool Use output to langextract format
+            # Tool Use returns: {"extractions": [{"extraction_class": "X", "extraction_text": "Y", "attributes": {...}}]}
+            # langextract expects: {"extractions": [{"X": "Y", "X_attributes": {...}}]}
             tool_input = tool_use_part.get("input") or {}
-            return json.dumps(tool_input)
+            extractions = tool_input.get("extractions", [])
+            transformed = []
+            for ext in extractions:
+                cls_name = ext.get("extraction_class", "")
+                item = {cls_name: ext.get("extraction_text", "")}
+                attrs = ext.get("attributes")
+                if attrs is not None:
+                    item[f"{cls_name}_attributes"] = attrs
+                transformed.append(item)
+            return json.dumps({"extractions": transformed})
 
         for part in content:
             if isinstance(part, dict) and "text" in part:
@@ -359,8 +369,11 @@ class BedrockLanguageModel(lx.core.base_model.BaseLanguageModel):
         config = self.set_config(kwargs)
 
         # Check if schema was provided by langextract (when use_schema_constraints=True)
+        # Schema can come from kwargs OR from apply_schema() which stores in self._schema
         schema_dict = kwargs.get("schema", None)
-        
+        if schema_dict is None and self._schema is not None:
+            schema_dict = self._schema._json_schema
+
         if schema_dict is not None:
             # Schema provided - use Tool Use API to enforce structure
             # This is the AWS-recommended approach for reliable structured output

--- a/tests/test_converse.py
+++ b/tests/test_converse.py
@@ -217,9 +217,12 @@ def test_converse_schema_extraction_no_executor(monkeypatch):
     assert isinstance(output, str)
     parsed = json.loads(output)
 
-    # Verify the structure matches what was in toolUse.input
+    # Verify the structure is transformed to langextract format
+    # Tool Use returns: {"extractions": [{"extraction_class": "X", "extraction_text": "Y", ...}]}
+    # Provider transforms to: {"extractions": [{"X": "Y", "X_attributes": {...}}]}
     assert "extractions" in parsed
     assert len(parsed["extractions"]) == 2
-    assert parsed["extractions"][0]["extraction_class"] == "character"
-    assert parsed["extractions"][0]["extraction_text"] == "ROMEO"
-    assert parsed["extractions"][1]["extraction_text"] == "JULIET"
+    assert parsed["extractions"][0]["character"] == "ROMEO"
+    assert parsed["extractions"][0]["character_attributes"] == {"family": "Montague"}
+    assert parsed["extractions"][1]["character"] == "JULIET"
+    assert parsed["extractions"][1]["character_attributes"] == {"family": "Capulet"}


### PR DESCRIPTION
…ction

Two issues prevented schema-based extraction from working:

1. Schema stored via apply_schema() wasn't being used in infer() - only checked kwargs but langextract stores schema in self._schema

2. Tool Use returns {"extractions": [{"extraction_class": "X", "extraction_text": "Y"}]}
   but langextract expects {"extractions": [{"X": "Y", "X_attributes": {...}}]}

This fix:
- Checks self._schema when schema not in kwargs
- Transforms Tool Use output to langextract's expected format

Fixes JSON parse error when using use_schema_constraints=True with Bedrock.